### PR TITLE
Define `certresolver` on router

### DIFF
--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -1,19 +1,45 @@
 # Etebase + Traefik Docker Example
 
-This is an example using traefik as reverse proxy for the etebase server.
+This is an example that uses Traefik as reverse proxy for the Etebase server.
 
-## Usage
+## Usage without HTTPS
+
+_Note: The EteSync web client will refuse to connect to non-HTTPS Etebase servers._
+
 Just run:
 
 ```console
-docker-compose up
+docker-compose up -d
 ```
 
 When ready, access: [http://etebase.localhost/admin](http://etebase.localhost/admin)
 
-## Advanced Security Example
-Same as above, but using HTTPS and permanent HTTP redirect. The commented sections show options for using the Let's Encrypt HTTP-01 challenge
+## Usage with HTTPS
+Make sure to edit `docker-compose.ssl.yml` and change `etebase.localhost` to your actual public hostname.
+
+There are three different ways to use HTTPS with Traefik:
+
+- Generate certificates with Let's Encrypt (**Recommended**)
+
+  Uncomment all of the commented lines in `docker-compose.ssl.yml` and change `postmaster@mydomain.com` to your email.
+
+  If you want to generate test certificates, add the following line at the end of the `command:` section:
+  ```yml
+  - "--certificatesresolvers.le.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+  ```
+  
+- Use your own SSL certificates
+
+  If you already have SSL certificates that you want to use with Traefik, instructions can be found [here](https://doc.traefik.io/traefik/https/tls/#user-defined).
+
+- Use Traefik's automatically generated certificates (**Not recommended**)
+
+  By default Traefik will generate SSL certificates however browsers and other applications may fail to connect as these certificates are untrusted by defaut.
+
+Once you're finished changing the configuration, just run:
 
 ```console
-docker-compose -f docker-compose.yml -f docker-compose.ssl.yml up
+docker-compose -f docker-compose.yml -f docker-compose.ssl.yml up -d
 ```
+
+When ready, access: `https://etebase.yourdomain/admin`

--- a/examples/traefik/docker-compose.ssl.yml
+++ b/examples/traefik/docker-compose.ssl.yml
@@ -11,6 +11,7 @@ services:
       traefik.http.routers.etebase.entrypoints: "websecure"
       traefik.http.routers.etebase.service: "etebase"
       traefik.http.routers.etebase.tls: "true"
+      #traefik.http.routers.etebase.tls.certresolver: "http-01"
 
   traefik:
     command:
@@ -23,7 +24,6 @@ services:
       #- "--entrypoints.websecure.http.tls.certResolver=http-01"
       #- "--certificatesresolvers.http-01.acme.httpchallenge=true"
       #- "--certificatesresolvers.http-01.acme.httpchallenge.entrypoint=web"
-      #- "--certificatesresolvers.http-01.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       #- "--certificatesresolvers.http-01.acme.email=postmaster@mydomain.com"
       #- "--certificatesresolvers.http-01.acme.storage=/letsencrypt/acme.json"
     ports:


### PR DESCRIPTION
The old line `"--entrypoints.websecure.http.tls.certResolver=http-01"` didn't work for me, so I changed it to define the `tls.certresolver` on the `etebase` router. I also updated the README for the Traefik example.