### PR TITLE
Wrong container port in examples/standalone/docker-compose.yml is corrected.

### DIFF
--- a/examples/standalone/docker-compose.yml
+++ b/examples/standalone/docker-compose.yml
@@ -15,4 +15,4 @@ services:
       SUPER_PASS: Change_M3
     restart: always
     ports:
-      - "80:80"
+      - "80:3735"


### PR DESCRIPTION
The container port in examples/standalone/docker-compose.yml is corrected to 3735. Now admin panel can be accessed from http://localhost/admin