### PR TITLE
Add support for setting Redis URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The available Etebase settings are set in the `/data/etebase-server.ini` file, i
 - **LANGUAGE_CODE**: Django language code, default: `en-us`;
 - **TIME_ZONE**: time zone, defaults to `UTC`, must be a valid ´tz database name´, valid names can be found at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>;
 - **DEBUG_DJANGO**²: enables Django Debug mode, not recommended for production defaults to `false`.
+- **REDIS_URI**: set Redis URI (optional)
 
 **²** for more details please take look at the [Etebase Server README.md](https://github.com/etesync/server#configuration)
 

--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -87,6 +87,7 @@ init_env() {
 
   file_env 'DB_ENGINE' 'sqlite'
   file_env 'DATABASE_NAME'
+  file_env 'REDIS_URI'
 
   if [ "${DB_ENGINE}" = "sqlite" ]; then
     local _DB_FILENAME
@@ -183,10 +184,16 @@ media_root = ${MEDIA_ROOT}
 media_url =  /user-media/
 language_code = ${LANGUAGE_CODE}
 time_zone = ${TIME_ZONE}
-
-[allowed_hosts]
-allowed_host1 = ${ALLOWED_HOSTS}
 " >"${ETEBASE_EASY_CONFIG_PATH}"
+
+  if [ -z "${REDIS_URI}" ]; then
+    echo "redis_uri = ${REDIS_URI}
+" >>"${ETEBASE_EASY_CONFIG_PATH}"
+  fi
+
+  echo "[allowed_hosts]
+allowed_host1 = ${ALLOWED_HOSTS}
+" >>"${ETEBASE_EASY_CONFIG_PATH}"
 
   if [ "${DB_ENGINE}" = "postgres" ]; then
     file_env 'DATABASE_USER' "${DATABASE_NAME}"


### PR DESCRIPTION
EteSync allows using Redis by setting `global.redis_uri`. [Easy config support was added a while ago](https://github.com/etesync/server/commit/848580604673f93fc54c9ea76b1aedd305b113af).

I recently borked my Docker installation, so I'm unable to test this, sorry 😞 I would be grateful if you could verify my change.