### PR TITLE
Disable autoindexing in the production nginx config example

### DIFF
--- a/examples/production/default-ssl.conf
+++ b/examples/production/default-ssl.conf
@@ -20,12 +20,10 @@ server {
     client_max_body_size 75M;   # adjust to taste
 
     location /static/ {
-        autoindex on;
         alias /srv/etebase/static/; # Project's static files
     }
 
     location /user-media/ {
-        autoindex on;
         alias /srv/etebase/media/; 
     }
 

--- a/examples/production/default.conf
+++ b/examples/production/default.conf
@@ -13,12 +13,10 @@ server {
     client_max_body_size 75M;   # adjust to taste
 
     location /static/ {
-        autoindex on;
         alias /srv/etebase/static/; # Project's static files
     }
 
     location /user-media/ {
-        autoindex on;
         alias /srv/etebase/media/; 
     }
 


### PR DESCRIPTION
See discussion #191.