### PR TITLE
fix(entrypoint.sh): parse config

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -295,7 +295,7 @@ if [ -e "${ETEBASE_EASY_CONFIG_PATH}" ]; then
 	check_perms "$(grep secret_file "${ETEBASE_EASY_CONFIG_PATH}" | sed -e 's/secret_file = //g')"
 	check_perms "$(grep media_root "${ETEBASE_EASY_CONFIG_PATH}" | sed -e 's/media_root = //g')" 'w'
 	if grep sqlite3 "${ETEBASE_EASY_CONFIG_PATH}" >/dev/null; then
-		check_perms "$(grep name "${ETEBASE_EASY_CONFIG_PATH}" | sed -e 's/name = //g')" 'w'
+		check_perms "$(grep '^name = ' "${ETEBASE_EASY_CONFIG_PATH}" | sed -e 's/name = //g')" 'w'
 	fi
 fi
 


### PR DESCRIPTION
I'm using domain name with TLD "name" (i.e. `allowed_host1 = etesync.example.name`) and this result in false match and scary log output on container start:
```
2024-06-14T08:41:56+00:00 [Info] [Entrypoint]: Check permission of allowed_host1 = etesync.example.name
/data/db.sqlite3
2024-06-14T08:41:56+00:00 [Info] [Entrypoint]: allowed_host1 = etesync.example.name
/data/db.sqlite3 does not exist
```