### PR TITLE
Fix typo in entrypoint.sh

### DIFF
--- a/context/entrypoint.sh
+++ b/context/entrypoint.sh
@@ -223,7 +223,8 @@ gen_inifile() {
 		EOF
 	fi
 
-	echo '[allowed_hosts]' >> "${ETEBASE_EASY_CONFIG_PATH}"local -a AHOSTS
+	echo '[allowed_hosts]' >> "${ETEBASE_EASY_CONFIG_PATH}"
+	local -a AHOSTS
 	local IFS=,
 	read -ra AHOSTS <<< "${ALLOWED_HOSTS}"
 	for i in "${!AHOSTS[@]}"; do


### PR DESCRIPTION
There is a typo in `contexts/entrypoint.sh`; it is missing a newline. Therefore, it won't add the `[allowed_hosts]` line, and the `allowed_hosts{n}` instructions won't be taken into account. 

If you build the image and run it, you will notice that you always get an `Invalid host header` because of this.

This issue was introduced by commit `1d6c9cc985617930442f366724244412b66f45bc`.