### PR TITLE
Non-standard port support in Nginx configuration

### DIFF
--- a/examples/production/default-ssl.conf
+++ b/examples/production/default-ssl.conf
@@ -35,7 +35,7 @@ server {
         proxy_set_header Connection "upgrade";
 
         proxy_redirect off;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;

--- a/examples/production/default.conf
+++ b/examples/production/default.conf
@@ -28,7 +28,7 @@ server {
         proxy_set_header Connection "upgrade";
 
         proxy_redirect off;
-        proxy_set_header Host $httphost;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;

--- a/examples/production/default.conf
+++ b/examples/production/default.conf
@@ -28,7 +28,7 @@ server {
         proxy_set_header Connection "upgrade";
 
         proxy_redirect off;
-        proxy_set_header Host $host;
+        proxy_set_header Host $httphost;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;


### PR DESCRIPTION
When using a non standard port, the default Nginx configuration leads to an CSRF error. Using $http_host fixes it.
See https://stackoverflow.com/a/15414811 for explanation.